### PR TITLE
Changed profile_image_url to profile_image_url_https …

### DIFF
--- a/nextend-twitter-connect/nextend-twitter-connect.php
+++ b/nextend-twitter-connect/nextend-twitter-connect.php
@@ -213,7 +213,7 @@ function new_twitter_login_action() {
           wp_set_auth_cookie($ID, true, $secure_cookie);
           $user_info = get_userdata($ID);
           do_action('wp_login', $user_info->user_login, $user_info);
-          update_user_meta($ID, 'twitter_profile_picture', $resp->profile_image_url);
+          update_user_meta($ID, 'twitter_profile_picture', $resp->profile_image_url_https);
           do_action('nextend_twitter_user_logged_in', $ID, $resp, $tmhOAuth);
         }
       } else {


### PR DESCRIPTION
… to prevent mixed content warnings on websites with secure connections.

API documentation for "Users" here:
https://dev.twitter.com/overview/api/users